### PR TITLE
add support for setting kind, location and plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ output "api_management_service_id" {
 
 (Required) The name of the resource group in which to create the template deployment.
 
+
+### location
+
+(Optional) Specifies the supported Azure location. Most resource types require a location, but some types (such as a role assignment) don't require a location.
+
 ### api_version
 
 (Required) Version of the REST API to use for creating the resource.
@@ -90,6 +95,10 @@ Specifies the mode that is used to deploy resources. This value could be either 
 
 (Required) Type of the resource. This value is a combination of the namespace of the resource provider and the resource type (such as `Microsoft.Storage/storageAccounts`).
 
+### plan
+
+(Optional) Some resources allow values that define the plan to deploy. For example, you can specify the marketplace image for a virtual machine.
+
 ### properties
 
 (Optional) Resource-specific configuration settings. The values for the properties are the same as the values you provide in the request body for the REST API operation (PUT method) to create the resource.
@@ -97,6 +106,10 @@ Specifies the mode that is used to deploy resources. This value could be either 
 ### sku
 
 (Optional) Some resources allow values that define the SKU to deploy. For example, you can specify the type of redundancy for a storage account.
+
+### kind
+
+(Optional) Some resources allow a value that defines the type of resource you deploy. For example, you can specify the type of Cosmos DB to create.
 
 ### tags
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~> 1.12"
+  version = "~> 1.13"
 }
 
 resource "azurerm_template_deployment" "resource" {
@@ -15,7 +15,16 @@ resource "azurerm_template_deployment" "resource" {
         "apiVersion": {
             "type": "string"
         },
+        "kind": {
+            "type": "string"
+        },
+        "location": {
+            "type": "string"
+        },
         "name": {
+            "type": "string"
+        },
+        "plan": {
             "type": "string"
         },
         "properties": {
@@ -33,9 +42,11 @@ resource "azurerm_template_deployment" "resource" {
             "apiVersion": "[parameters('apiVersion')]",
             "name": "[parameters('name')]",
             "type": "${var.type}",
-            "location": "[resourceGroup().location]",
+            ${var.location != "" ? "\"location\":\"[parameters('location')]\"," : ""}
             "properties": "[json(parameters('properties'))]",
-            "sku": "[json(parameters('sku'))]",
+            ${var.kind != "" ? "\"kind\":\"[parameters('kind')\"," : ""}
+            ${length(var.plan) > 0 ? "\"plan\":\"[json(parameters('plan'))]\"," : ""}
+            ${length(var.sku) > 0 ? "\"sku\":\"[json(parameters('sku'))]\"," : ""}
             "tags": "[json(parameters('tags'))]"
         }
     ],
@@ -50,7 +61,10 @@ DEPLOY
 
   parameters {
     "apiVersion" = "${var.api_version}"
+    "kind"       = "${var.kind}"
+    "location"   = "${var.location}"
     "name"       = "${var.name}"
+    "plan"       = "${jsonencode(var.plan)}"
     "properties" = "${jsonencode(var.properties)}"
     "sku"        = "${jsonencode(var.sku)}"
     "tags"       = "${jsonencode(var.tags)}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,9 @@
 output "id" {
-  value = "${lookup(azurerm_template_deployment.resource.outputs, "id", "")}"
+  description = "The resource ID."
+  value       = "${lookup(azurerm_template_deployment.resource.outputs, "id", "")}"
 }
 
 output "template_deployment_id" {
-  value = "${azurerm_template_deployment.resource.id}"
+  description = "The template deployment ID."
+  value       = "${azurerm_template_deployment.resource.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,16 @@ variable "deployment_mode" {
   description = "Specifies the mode that is used to deploy resources. This value could be either Incremental or Complete."
 }
 
+variable "kind" {
+  default     = ""
+  description = "Some resources allow a value that defines the type of resource you deploy. For example, you can specify the type of Cosmos DB to create."
+}
+
+variable "location" {
+  default     = ""
+  description = "Some resources allow a value that defines the type of resource you deploy. For example, you can specify the type of Cosmos DB to create."
+}
+
 variable "name" {
   description = "Name of the resource. The name must follow URI component restrictions defined in RFC3986."
 }


### PR DESCRIPTION
since this update adds `location` then we also need to set it for most resources, for example:
```
module "integration_account" {
  source         = "innovationnorway/resource/azurerm"
  api_version    = "2016-06-01"
  type           = "Microsoft.Logic/IntegrationAccounts"
  name           = "my-integration-account"
  resource_group = "${azurerm_resource_group.integration_account.name}"
  location       = "${azurerm_resource_group.integration_account.location}"

  sku {
    name = "Standard"
  }
}
```