### PR TITLE
add random generated deployment name option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,11 @@ provider "azurerm" {
   version = "~> 1.13"
 }
 
+resource "random_uuid" "random_deployment_name" { }
+
+
 resource "azurerm_template_deployment" "resource" {
-  name                = "${var.name}"
+  name                = "${var.random_deployment_name? random_uuid.random_deployment_name.result : var.name}"
   resource_group_name = "${var.resource_group_name}"
   deployment_mode     = "${var.deployment_mode}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,10 @@ variable "name" {
   description = "Name of the resource. The name must follow URI component restrictions defined in RFC3986."
 }
 
+variable "random_deployment_name" {
+  description = "Enable randomly generated deployment name. Used when resource name cannot fit the deployment name restrictions."
+  default = false
+}
 variable "plan" {
   default     = {}
   description = "Some resources allow values that define the plan to deploy. For example, you can specify the marketplace image for a virtual machine."


### PR DESCRIPTION
Some azure resources (like cosmos SQL containers) need a name like "account_name/sql/db_name/resource" but the deployment name cannot contains "/", so a custom/random deployment name is needed