### PR TITLE
enable dependency between ARM module instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_template_deployment" "resource" {
 
   template_body = <<DEPLOY
 {
-    // This ARM depends on : "${var.depends_on}"
+    // This ARM depends on : "${var.depends_on[0]}"
     "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,6 @@ resource "azurerm_template_deployment" "resource" {
 
   template_body = <<DEPLOY
 {
-    "comments": "This deployment must follows : ${var.depends_on[0]} ",
     "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
@@ -51,6 +50,7 @@ resource "azurerm_template_deployment" "resource" {
             ${length(var.plan) > 0 ? "\"plan\":\"[json(parameters('plan'))]\"," : ""}
             ${length(var.sku) > 0 ? "\"sku\":\"[json(parameters('sku'))]\"," : ""}
             "tags": "[json(parameters('tags'))]"
+            "comments": "This deployment must follows : ${var.depends_on[0]} ",
         }
     ],
  "outputs": {

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_template_deployment" "resource" {
 
   template_body = <<DEPLOY
 {
-    // This ARM depends on : "${var.depends_on[0]}"
+    "_comment": " This ARM depends on : "${var.depends_on[0]}" "
     "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/main.tf
+++ b/main.tf
@@ -5,12 +5,13 @@ provider "azurerm" {
 resource "random_uuid" "random_deployment_name" {}
 
 resource "azurerm_template_deployment" "resource" {
-  name                = "${var.random_deployment_name? random_uuid.random_deployment_name.result : var.name}"
+  name                = "${var.random_deployment_name ? random_uuid.random_deployment_name.result : var.name}"
   resource_group_name = "${var.resource_group_name}"
   deployment_mode     = "${var.deployment_mode}"
 
   template_body = <<DEPLOY
 {
+    // This ARM depends on : "${var.depends_on}"
     "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/main.tf
+++ b/main.tf
@@ -49,8 +49,8 @@ resource "azurerm_template_deployment" "resource" {
             ${var.kind != "" ? "\"kind\":\"[parameters('kind')]\"," : ""}
             ${length(var.plan) > 0 ? "\"plan\":\"[json(parameters('plan'))]\"," : ""}
             ${length(var.sku) > 0 ? "\"sku\":\"[json(parameters('sku'))]\"," : ""}
-            "tags": "[json(parameters('tags'))]"
-            "comments": "This deployment must follows : ${var.depends_on[0]} ",
+            "tags": "[json(parameters('tags'))]",
+            "comments": "This deployment must follows : ${var.depends_on[0]} "
         }
     ],
  "outputs": {

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_template_deployment" "resource" {
 
   template_body = <<DEPLOY
 {
-    "_comment": " This ARM depends on : "${var.depends_on[0]}" "
+    "comments": "This deployment must follows : ${var.depends_on[0]} ",
     "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,11 @@ variable "type" {
 }
 
 variable "enable_output" {
-  description = "Disable output collection for resources that doesn't support it"
+  description = "Disable output collection for resources that doesn't support it."
   default     = false
+}
+
+variable "depends_on" {
+  description = "Set a workaround for implementing depends_on between different arm modules"
+  default     = "none"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -61,5 +61,5 @@ variable "enable_output" {
 
 variable "depends_on" {
   description = "Set a workaround for implementing depends_on between different arm modules"
-  default     = "none"
+  default     = ["none"]
 }


### PR DESCRIPTION
Use the ARM comment field to set a dependency between the azurerm_template_deployment.
The variable depends_on supports a list of objects

example:
module "child" {
 [ parameters ]
 depends_on             = ["${module.fathermodule.template_deployment_id}"]
 [ parameters ]
}
 